### PR TITLE
Fix grammatical issue in encapsulation explanation

### DIFF
--- a/docs/csharp/fundamentals/object-oriented/index.md
+++ b/docs/csharp/fundamentals/object-oriented/index.md
@@ -18,7 +18,7 @@ In C#, the definition of a type&mdash;a class, struct, or record&mdash;is like a
 
 ## Encapsulation  
 
- *Encapsulation* is sometimes referred to as the first pillar or principle of object-oriented programming. A class or struct can specify how accessible each of its members is to code outside of the class or struct. Member not intended for consumers outside of the class or assembly are hidden to limit the potential for coding errors or malicious exploits. For more information, see the [Object-oriented programming](../tutorials/oop.md) tutorial.
+ *Encapsulation* is sometimes referred to as the first pillar or principle of object-oriented programming. A class or struct can specify how accessible each of its members is to code outside of the class or struct. Members not intended for consumers outside of the class or assembly are hidden to limit the potential for coding errors or malicious exploits. For more information, see the [Object-oriented programming](../tutorials/oop.md) tutorial.
 
 ## Members
 


### PR DESCRIPTION
### Summary
This pull request corrects a minor grammatical issue in the [object-oriented programming fundamentals documentation](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/object-oriented/).

### Details
The original sentence reads:

> "Member not intended for consumers outside of the class or assembly are hidden..."

This has been corrected to:

> "Members not intended for consumers outside of the class or assembly are hidden..."

### Reason
The correction improves grammatical accuracy and clarity. The context refers to multiple class or struct members, so the plural form "Members" is appropriate.

### Impact
No technical content was changed. This is a non-functional documentation improvement.
